### PR TITLE
Fixes gem install in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can use both RMQ Plugins and ProMotion Add-ons
 ## Quick start
 
 ```
-gem install red_potion
+gem install redpotion
 
 potion create my_app
 bundle


### PR DESCRIPTION
Looks like we use `redpotion` on rubygems, not `red_potion` so updated it in the readme.
