### PR TITLE
Make append works on more screen type like PM::TableScreen, 

### DIFF
--- a/lib/project/ruby_motion_query/ext.rb
+++ b/lib/project/ruby_motion_query/ext.rb
@@ -66,7 +66,7 @@ class UIViewController
   end
 end
 
-class ProMotion::Screen
+class ProMotion::ScreenModule
   def append(view_or_constant, style=nil, opts = {})
     view.append(view_or_constant, style, opts)
   end


### PR DESCRIPTION
In order to make append syntax(https://github.com/infinitered/redpotion#you-can-use-app-directly-in-code-which-is-the-same-as-rmqapp) works on all type of ProMotion Screen, like PM::TableScreen, it should be extend under ProMotion::ScreenModule not just ProMotion::Screen. Because all type of ProMotion screens have this line of code:  `include ProMotion::ScreenModule`.

I am try to write some test file, but I think the old test for PM::Screen should works. If it pass, it should be works well on other type of screen, like PM::TableScreen.

Please look at those link:
https://github.com/clearsightstudio/ProMotion/wiki/Guide:-Making-Your-Own-Screens
https://github.com/clearsightstudio/ProMotion/blob/master/lib/ProMotion/screen/screen.rb#L5
https://github.com/clearsightstudio/ProMotion/blob/master/lib/ProMotion/table/table_screen.rb#L3
https://github.com/clearsightstudio/ProMotion-form/blob/master/lib/ProMotion/form/form_screen.rb#L3
