### PR TITLE
Stop duplicate calls to on_load

### DIFF
--- a/app/screens/metal_table_screen.rb
+++ b/app/screens/metal_table_screen.rb
@@ -15,7 +15,6 @@ class MetalTableScreen < UITableViewController
 
   def on_load
     load_data
-
     view.tap do |table|
       table.delegate = self
       table.dataSource = self

--- a/lib/project/ruby_motion_query/ext.rb
+++ b/lib/project/ruby_motion_query/ext.rb
@@ -92,7 +92,6 @@ class UIView
     rmq.stylesheet = value
   end
 end
-
 class UIViewController
   def on_load
   end
@@ -156,14 +155,17 @@ class UIViewController
 
   def view_did_load
   end
+
   def viewDidLoad
     if self.class.rmq_style_sheet_class
       self.rmq.stylesheet = self.class.rmq_style_sheet_class
       self.view.rmq.apply_style :root_view
     end
+    self.view_did_load unless pm_handles_did_load?
+  end
 
-    self.view_did_load
-    self.on_load
+  def pm_handles_did_load?
+    self.is_a?(ProMotion::ViewController) || self.is_a?(ProMotion::TableScreen)
   end
 
   def view_will_appear(animated)


### PR DESCRIPTION
Fixes duplicate calls, but changes MetalTable sample screen to implement cocoatouch method because the `view_did_load` is no longer wired up properly after the updates in `ext.rb`
