### PR TITLE
Fixes CLI hang & makes sure to exclude all CDQ when using --skip-cdq

### DIFF
--- a/bin/potion
+++ b/bin/potion
@@ -212,6 +212,8 @@ class PotionCommandLine
         remove_lines('app/app_delegate.rb', /include CDQ|cdq.setup/, show_output)
         remove_lines('Rakefile', /schema:build/, show_output)
         File.delete('schemas/0001_initial.rb') if File.exists?('schemas/0001_initial.rb')
+        File.delete('resources/cdq.yml') if File.exists?('resources/cdq.yml')
+        Dir.delete('schemas') if Dir.exists?('schemas')
       when 'afmotion'
         remove_lines('Gemfile', /gem ('|")afmotion('|")/, show_output)
       else

--- a/bin/potion
+++ b/bin/potion
@@ -152,7 +152,8 @@ class PotionCommandLine
         @screen_base = template_name.split('_').collect(&:capitalize).join
         template_name = 'screen'
       else
-        puts `potion create #{template_name} #{name}`
+        # we dont have templates for these fallback to RMQ
+        puts `rmq create #{template_name} #{name}`
         return
       end
 


### PR DESCRIPTION
 * fixes #43  introduced in 3c54fb1914a663eff8b2f7fd2fd6f6c9a357fc56
 * fixes #42 