### PR TITLE
Make newclear a runtime dependency.

### DIFF
--- a/redpotion.gemspec
+++ b/redpotion.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ProMotion", "~> 2.2.1"
   spec.add_runtime_dependency "motion_print"
   spec.add_runtime_dependency "motion-cocoapods"
+  spec.add_runtime_dependency "newclear"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "webstub"
-  spec.add_development_dependency "newclear"
 end


### PR DESCRIPTION
Since we aren't developing on newclear this should be a runtime dependency in redpotion. 