### PR TITLE
Allows the user to specify the cell template within the model

### DIFF
--- a/app/screens/contributer_screen.rb
+++ b/app/screens/contributer_screen.rb
@@ -11,6 +11,7 @@ class ContributerScreen < PM::DataTableScreen
   end
 
   def on_refresh
+    stop_refreshing
   end
 
   # Remove if you are only supporting portrait

--- a/lib/project/pro_motion/data_table_screen.rb
+++ b/lib/project/pro_motion/data_table_screen.rb
@@ -33,13 +33,17 @@ module ProMotion
       return [] if data_model.nil?
 
       data_model.send(data_scope).collect do |c|
-        {
-          cell_class: cell_class,
-          properties: properties.inject({}) do |hash, element|
-            hash[element.first] = c.send(element.last)
-            hash
-          end
-        }
+        if c.respond_to?(:cell)
+          c.cell
+        else
+          {
+            cell_class: cell_class,
+            properties: properties.inject({}) do |hash, element|
+              hash[element.first] = c.send(element.last)
+              hash
+            end
+          }
+        end
       end
     end
 
@@ -48,11 +52,11 @@ module ProMotion
     def properties
       @properties ||= cell_properties[:template].reject do |k,v|
         k == :cell_class
-      end
+      end unless cell_properties[:template].nil?
     end
 
     def cell_class
-      @cell_class ||= cell_properties[:template][:cell_class]
+      @cell_class ||= cell_properties[:template].nil? ? nil : cell_properties[:template][:cell_class]
     end
 
     def data_model

--- a/spec/pro_motion/data_table_screen_spec.rb
+++ b/spec/pro_motion/data_table_screen_spec.rb
@@ -58,4 +58,21 @@ describe 'DataTableScreen' do
     TestDataTableScreen.new.cell_data[0][:properties][:name].should.equal('one')
     TestDataTableScreen.new.cell_data[1][:properties][:name].should.equal('two')
   end
+
+  it 'should use a the cell method in the model when specified' do
+    class TestModel
+      def cell
+        {
+          cell_class: TestCell,
+          properties: {
+            name: 'one',
+          }
+        }
+      end
+    end
+
+    TestDataTableScreen.cell(model: TestModel)
+    TestDataTableScreen.new.cell_data.count.should.equal(2)
+    TestDataTableScreen.new.cell_data[0][:properties][:name].should.equal('one')
+  end
 end


### PR DESCRIPTION
So they'd specify

```ruby
class MyModel < CDQManagedObject
  def cell
    {
      cell_class: WhateverCell,
      properties: {
        name: :name, 
        something_else: :datetime
      }
    }
  end
end
```

I think this will make it easier to create the cell templates that may need to be different based on the properties of the model contents itself instead of specifying one globally for the entire screen.