### PR TITLE
ProMotion TableScreen: Call setup when cell are new or reused

### DIFF
--- a/lib/project/pro_motion/table.rb
+++ b/lib/project/pro_motion/table.rb
@@ -10,9 +10,9 @@ module ProMotion
         new_cell.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleLeftMargin|UIViewAutoresizingFlexibleRightMargin
         new_cell.clipsToBounds = true # fix for changed default in 7.1
         new_cell.send(:on_load) if new_cell.respond_to?(:on_load)
-        new_cell.setup(data_cell, self)
         new_cell
       end
+      table_cell.setup(data_cell, self) if table_cell.respond_to?(:setup)
       table_cell.send(:on_reuse) if !new_cell && table_cell.respond_to?(:on_reuse)
       table_cell
     end


### PR DESCRIPTION
When using PM:TableScreen the content of the reused TableCell's are not setup with new content.
Update to ProMotion 2.3+ #69 obsoletes this patch as its remove the overwrite of this method in RedPotion.