### PR TITLE
Allow PM to handle delegates for grouped tables

### DIFF
--- a/app/test_objects/test_grouped_table_screen.rb
+++ b/app/test_objects/test_grouped_table_screen.rb
@@ -1,0 +1,4 @@
+class TestGroupedTableScreen < PM::GroupedTableScreen
+  include DelegateTestAttributes
+  def table_data; @table_data ||= []; end
+end

--- a/app/test_objects/test_table_screen.rb
+++ b/app/test_objects/test_table_screen.rb
@@ -1,0 +1,4 @@
+class TestTableScreen < PM::TableScreen
+  include DelegateTestAttributes
+  def table_data; @table_data ||= []; end
+end

--- a/lib/project/ext/ui_view_controller.rb
+++ b/lib/project/ext/ui_view_controller.rb
@@ -161,6 +161,6 @@ class UIViewController
   private
 
   def pm_handles_delegates?
-    self.is_a?(ProMotion::ViewController) || self.is_a?(ProMotion::TableScreen)
+    self.is_a?(ProMotion::ViewController) || self.is_a?(ProMotion::TableViewController)
   end
 end

--- a/spec/ext/ui_view_controller_spec.rb
+++ b/spec/ext/ui_view_controller_spec.rb
@@ -166,6 +166,18 @@ describe 'UIViewController' do
     end
   end
 
+  describe 'when using a PM::TableScreen' do
+    tests TestTableScreen
+
+    behaves_like 'proper delegate caller'
+  end
+
+  describe 'when using a PM::GroupedTableScreen' do
+    tests TestGroupedTableScreen
+
+    behaves_like 'proper delegate caller'
+  end
+
   describe 'when using a controller' do
     tests TestController
 


### PR DESCRIPTION
ProMotion has both a `TableScreen` class and a `GroupedTableScreen` class, both of which inherit from `TableViewController`.

The `pm_handles_delegates?` method properly refers to `ViewController` (which both `PM::Screen` and `PM::WebScreen` inherit from), but refers directly to `PM::TableScreen`, excluding `PM::GroupedTableScreen`. As a result, `view_did_load` was firing twice on GroupedTableScreens.

The method now checks against `TableViewController` instead. I also added specs to run the 'proper delegate caller' specs on both TableScreen and GroupedTableScreen.