### PR TITLE
automate bundle and pod installation

### DIFF
--- a/bin/potion
+++ b/bin/potion
@@ -103,11 +103,14 @@ class PotionCommandLine
 
       `motion create --template=git@github.com:infinitered/redpotion-template.git #{app_name}`
 
+      ["bundle", "rake pod:install"].each do |command|
+        puts "Running #{command}..."
+
+        system("cd #{app_name}; #{command}")
+      end
+
       puts %{
-      Complete. Things you should do:
-      > cd #{app_name}
-      > bundle
-      > rake pod:install
+      Complete. Things you can do:
       > rake spec
       > rake
       (main)> exit


### PR DESCRIPTION
This will automatically run both `bundle` and `rake pod:install` something that is required every time, but easily overlooked. It will also output this to the shell so the user can see the commands taking place.

```bash
👉 potion create example-app
Creating app
Template Cloning redpotion-template template
Template redpotion-template already exists, performing a pull
From github.com:infinitered/redpotion-template
 * branch            master     -> FETCH_HEAD
Running bundle...
Fetching gem metadata from https://rubygems.org/............
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Resolving dependencies...
Using rake 10.4.2

# etc etc etc
```