### PR TITLE
Fixes #91

### DIFF
--- a/lib/project/ext/pm_delegate.rb
+++ b/lib/project/ext/pm_delegate.rb
@@ -1,0 +1,26 @@
+# FXFormViewController is a top level class
+class FXFormViewController < UIViewController
+end
+
+# Defines which ProMotion classes handle delegates
+module ProMotion
+  class ViewController < UIViewController
+    def class_handles_delegates?
+      true
+    end
+  end
+
+  class TableViewController < UITableViewController
+    def class_handles_delegates?
+      true
+    end
+  end
+
+  # Include the entire class declaration chain for people that may not have
+  # the ProMotion-form gem installed.
+  class FormViewController < FXFormViewController
+    def class_handles_delegates?
+      true
+    end
+  end
+end

--- a/lib/project/ext/ui_view_controller.rb
+++ b/lib/project/ext/ui_view_controller.rb
@@ -157,6 +157,6 @@ class UIViewController
   private
 
   def pm_handles_delegates?
-    self.is_a?(ProMotion::ViewController) || self.is_a?(ProMotion::TableViewController)
+    self.is_a?(ProMotion::ViewController) || self.is_a?(ProMotion::TableViewController) || self.is_a?(ProMotion::FormScreen)
   end
 end

--- a/lib/project/ext/ui_view_controller.rb
+++ b/lib/project/ext/ui_view_controller.rb
@@ -157,6 +157,6 @@ class UIViewController
   private
 
   def pm_handles_delegates?
-    self.is_a?(ProMotion::ViewController) || self.is_a?(ProMotion::TableViewController) || self.is_a?(ProMotion::FormScreen)
+    self.respond_to?(:class_handles_delegates?) && self.class_handles_delegates?
   end
 end

--- a/lib/project/pro_motion_form/form_screen.rb
+++ b/lib/project/pro_motion_form/form_screen.rb
@@ -1,0 +1,8 @@
+module ProMotion
+  class FormScreen
+    # Defining this here is critical for PM::FormScreens to not fire delegate
+    # methods twice. This class must be defined even if we aren't using
+    # the ProMotion-form gem so that our pm_handles_delegates? method
+    # works properly for those people who _do_ use PM::FormScreen
+  end
+end

--- a/lib/project/pro_motion_form/form_screen.rb
+++ b/lib/project/pro_motion_form/form_screen.rb
@@ -1,8 +1,0 @@
-module ProMotion
-  class FormScreen
-    # Defining this here is critical for PM::FormScreens to not fire delegate
-    # methods twice. This class must be defined even if we aren't using
-    # the ProMotion-form gem so that our pm_handles_delegates? method
-    # works properly for those people who _do_ use PM::FormScreen
-  end
-end


### PR DESCRIPTION
Defining the PM::FormScreen class seems like the only option to support it for those who don't use the gem and not crash.