### PR TITLE
calls super on UICollectionViewCell

### DIFF
--- a/templates/collection_view_screen/app/views/name_cell.rb
+++ b/templates/collection_view_screen/app/views/name_cell.rb
@@ -10,6 +10,7 @@ class <%= @name_camel_case %>Cell < UICollectionViewCell
   end
 
   def prepareForReuse
+    super
     @reused = true
   end
 


### PR DESCRIPTION
Apple documentation specifies:

> The default implementation of this method does nothing. However, when overriding this method, it is recommended that you call super anyway.

https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UICollectionReusableView_class/index.html#//apple_ref/occ/instm/UICollectionReusableView/prepareForReuse