### PR TITLE
Update to use SDWebImage

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ Motion::Project::App.setup do |app|
   app.interface_orientations = [:portrait, :landscape_left, :landscape_right, :portrait_upside_down]
 
   app.pods do
-    pod "JMImageCache"
+    pod "SDWebImage"
   end
 
   app.development do

--- a/docs/cookbook/images.md
+++ b/docs/cookbook/images.md
@@ -37,7 +37,7 @@ image.from_view(my_view)
 
 ## Remote images
 
-You can set `remote_image` to a URL string or an instance of `NSURL` and it will automatically fetch the image and set the image (with caching) using the power of [JMImageCache](https://github.com/jakemarsh/JMImageCache).
+You can set `remote_image` to a URL string or an instance of `NSURL` and it will automatically fetch the image and set the image (with caching) using the power of [SDWebImage](https://github.com/rs/SDWebImage).
 
 ```ruby
 class MyStylesheet < ApplicationStylesheet

--- a/docs/cookbook/networking.md
+++ b/docs/cookbook/networking.md
@@ -2,13 +2,13 @@ RedPotion uses the following for networking:
 
 * AFNetworking pod
 * AFMotion gem
-* JMImageCache
+* SDWebImage
 
 -------
 
 ## Remote images
 
-You can set `remote_image` to a URL string or an instance of `NSURL` and it will automatically fetch the image and set the image (with caching) using the power of [JMImageCache](https://github.com/jakemarsh/JMImageCache).
+You can set `remote_image` to a URL string or an instance of `NSURL` and it will automatically fetch the image and set the image (with caching) using the power of [SDWebImage](https://github.com/rs/SDWebImage).
 
 You should always use `remote_image` for any image you download, it will cache it to memory and out to disk when it's appropriate. It does it async and is performant, even for a large table of images.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,4 +55,4 @@ You can use both RMQ Plugins and ProMotion Add-ons
 
 **Pods**
 
-* [JMImageCache](https://github.com/jakemarsh/JMImageCache)
+* [SDWebImage](https://github.com/rs/SDWebImage)

--- a/docs/new_features_for_rmq_and_promotion.md
+++ b/docs/new_features_for_rmq_and_promotion.md
@@ -96,7 +96,7 @@ end
 
 ### Remote image loading for UIImageView styler
 
-You can set `remote_image` to a URL string or an instance of `NSURL` and it will automatically fetch the image and set the image (with caching) using the power of [JMImageCache](https://github.com/jakemarsh/JMImageCache).
+You can set `remote_image` to a URL string or an instance of `NSURL` and it will automatically fetch the image and set the image (with caching) using the power of [SDWebImage](https://github.com/rs/SDWebImage).
 
 ```ruby
 class MyStylesheet < ApplicationStylesheet
@@ -112,11 +112,11 @@ class MyStylesheet < ApplicationStylesheet
 end
 ```
 
-In order to use this feature, you must add the `JMIMageCache` cocoapod to your project:
+In order to use this feature, you must add the `SDWebImage` cocoapod to your project:
 
 ```ruby
 app.pods do
-  pod 'JMImageCache'
+  pod 'SDWebImage'
 end
 ```
 

--- a/lib/project/ext/ui_image_view.rb
+++ b/lib/project/ext/ui_image_view.rb
@@ -1,11 +1,25 @@
 class UIImageView
 
   def remote_image=(value)
-    if self.respond_to?("setImageWithURL:placeholder:")
+    if !!defined?(SDWebImageManager)
+      @remote_image_operations ||= {}
+
+      # Cancel the previous remote operation if it exists
+      operation = @remote_image_operations[("%p" % self)]
+      if operation && operation.respond_to?(:cancel)
+        operation.cancel
+        @remote_image_operations[("%p" % self)] = nil
+      end
+
       value = NSURL.URLWithString(value) unless value.is_a?(NSURL)
-      self.setImageWithURL(value, placeholder:self.image)
+      @remote_image_operations[("%p" % self)] = SDWebImageManager.sharedManager.downloadWithURL(value,
+        options:SDWebImageRefreshCached,
+        progress:nil,
+        completed: -> image, error, cacheType, finished {
+        self.image = image unless image.nil?
+      })
     else
-      puts "\n[RedPotion ERROR]  tried to set remote_image without JMImageCache cocoapod. Please add this to your Rakefile: \n\napp.pods do\n  pod \"JMImageCache\"\nend\n"
+      puts "\n[RedPotion ERROR]  tried to set remote_image without SDWebImage cocoapod. Please add this to your Rakefile: \n\napp.pods do\n  pod \"SDWebImage\"\nend\n"
     end
   end
 

--- a/spec/helpers/load_image.rb
+++ b/spec/helpers/load_image.rb
@@ -1,3 +1,3 @@
-def load_image(path)
-  NSData.dataWithContentsOfFile(NSBundle.mainBundle.pathForResource(path, ofType:'jpeg'))
+def load_image(path, type = "jpeg")
+  NSData.dataWithContentsOfFile(NSBundle.mainBundle.pathForResource(path, ofType:type))
 end

--- a/spec/ruby_motion_query/stylers/ui_image_view_spec.rb
+++ b/spec/ruby_motion_query/stylers/ui_image_view_spec.rb
@@ -24,12 +24,10 @@ class StyleSheetForUIImageViewStylerTests < RubyMotionQuery::Stylesheet
 
 end
 
-describe 'RubyMotionQuery styler: UIImageView' do
+describe "RubyMotionQuery styler: UIImageView" do
   extend WebStub::SpecHelpers
 
   before do
-    SDWebImageManager.sharedManager.imageCache.clearMemory
-
     @vc = UIViewController.alloc.init
     @vc.rmq.stylesheet = StyleSheetForUIImageViewStylerTests
     @view_klass = UIImageView
@@ -38,6 +36,10 @@ describe 'RubyMotionQuery styler: UIImageView' do
     @grumpy_cat = UIImage.imageNamed('grumpy_cat')
     @url = 'http://somehost/image'
     WebStub::API.stub_request(:get, @url).to_return(body: load_image('homer'), content_type: "image/jpeg")
+  end
+
+  after do
+    SDWebImageManager.sharedManager.imageCache.clearMemory
   end
 
   it "should set a placeholder image" do
@@ -78,6 +80,20 @@ describe 'RubyMotionQuery styler: UIImageView' do
 
     wait 0.1 do
       view.image.should.not == nil
+    end
+  end
+
+  it "should fetch the image from memory" do
+    view = @vc.rmq.append!(@view_klass, :ui_image_view_remote)
+    view.image.should == @grumpy_cat
+
+    wait 0.1 do
+      view.image.should.not == @grumpy_cat
+      view.image = nil
+      view.image.should.be.nil
+      view.apply_style(:ui_image_view_remote)
+      # This should be instant since we have not cleared the cache
+      view.image.should.not.be.nil
     end
   end
 end

--- a/spec/ruby_motion_query/stylers/ui_image_view_spec.rb
+++ b/spec/ruby_motion_query/stylers/ui_image_view_spec.rb
@@ -28,6 +28,8 @@ describe 'RubyMotionQuery styler: UIImageView' do
   extend WebStub::SpecHelpers
 
   before do
+    SDWebImageManager.sharedManager.imageCache.clearMemory
+
     @vc = UIViewController.alloc.init
     @vc.rmq.stylesheet = StyleSheetForUIImageViewStylerTests
     @view_klass = UIImageView

--- a/spec/ruby_motion_query/stylers/ui_image_view_spec.rb
+++ b/spec/ruby_motion_query/stylers/ui_image_view_spec.rb
@@ -28,6 +28,7 @@ describe "RubyMotionQuery styler: UIImageView" do
   extend WebStub::SpecHelpers
 
   before do
+    WebStub::Protocol.disable_network_access!
     @vc = UIViewController.alloc.init
     @vc.rmq.stylesheet = StyleSheetForUIImageViewStylerTests
     @view_klass = UIImageView
@@ -39,6 +40,7 @@ describe "RubyMotionQuery styler: UIImageView" do
   end
 
   after do
+    WebStub::Protocol.enable_network_access!
     SDWebImageManager.sharedManager.imageCache.clearMemory
   end
 


### PR DESCRIPTION
Moves from JMImageCache to SDWebImage.

Note my operation storage methodology of using the instance's memory address in a var. Any thought about a better way of doing this with `UIImageView` when we don't necessarily know where the image view is (like in a table cell or a collection view) and we can't invalidate it in the `prepareForReuse` method of the cell?