### PR TITLE
Loosen RMQ and ProMotion dependencies - Fixes #107

### DIFF
--- a/redpotion.gemspec
+++ b/redpotion.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
 
   spec.executables << 'potion'
 
-  spec.add_runtime_dependency "ruby_motion_query", "~> 1.4.0"
-  spec.add_runtime_dependency "ProMotion", "~> 2.3.1"
+  spec.add_runtime_dependency "ruby_motion_query", ">= 1.4.0"
+  spec.add_runtime_dependency "ProMotion", ">= 2.3.1"
   spec.add_runtime_dependency "motion_print"
   spec.add_runtime_dependency "motion-cocoapods"
   spec.add_runtime_dependency "RedAlert"


### PR DESCRIPTION
Allows for future releases to be used in redpotion without a new redpotion
release.  When there is a change that directly impacts redpotion in a
dependant gem - we can bump these requirements to the new supported gem
version.