### PR TITLE
update ProMotion to 2.4.1 fix PM::TableScreen cell editing_style: :delete not work

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    redpotion (1.2.0)
-      ProMotion (~> 2.3.1)
+    redpotion (1.2.1)
+      ProMotion (~> 2.4.1)
       RedAlert
       motion-cocoapods
       motion_print
@@ -12,8 +12,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ProMotion (2.3.1)
+    ProMotion (2.4.1)
       methadone (~> 1.7)
+      motion_print (~> 1.0)
     RedAlert (1.1)
       ruby_motion_query (>= 1.3.4)
     activesupport (3.2.21)

--- a/app/screens/tasks_screen.rb
+++ b/app/screens/tasks_screen.rb
@@ -18,7 +18,8 @@ class TasksScreen < PM::TableScreen
           cell_class: TaskCell,
           properties: {
             my_title: "First task"
-          }
+          },
+          editing_style: :delete
         },
         {
           cell_class: TaskCell,

--- a/lib/project/version.rb
+++ b/lib/project/version.rb
@@ -1,3 +1,3 @@
 module RedPotion
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end

--- a/redpotion.gemspec
+++ b/redpotion.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'potion'
 
   spec.add_runtime_dependency "ruby_motion_query", "~> 1.4.0"
-  spec.add_runtime_dependency "ProMotion", "~> 2.3.1"
+  spec.add_runtime_dependency "ProMotion", "~> 2.4.1"
   spec.add_runtime_dependency "motion_print"
   spec.add_runtime_dependency "motion-cocoapods"
   spec.add_runtime_dependency "RedAlert"


### PR DESCRIPTION
ProMotion 2.3.1, PM::TableScreen cell editing_style: :delete not work