### PR TITLE
Require redalert as its a runtime dependency

### DIFF
--- a/lib/redpotion.rb
+++ b/lib/redpotion.rb
@@ -7,6 +7,7 @@ end
 require 'ruby_motion_query'
 require 'ProMotion'
 require 'motion_print'
+require 'redalert'
 
 lib_dir_path = File.dirname(File.expand_path(__FILE__))
 Motion::Project::App.setup do |app|


### PR DESCRIPTION
Similar to how we have to require motion_print, we should require redalert as well.