### PR TITLE
Use require_relative instead of unshift

### DIFF
--- a/bin/potion
+++ b/bin/potion
@@ -3,9 +3,7 @@
 require "erb"
 require "rubygems"
 require 'open-uri'
-
-$:.unshift(File.join(File.dirname(__FILE__), "/../lib/project"))
-require "version"
+require_relative "../lib/project/version"
 
 class PotionCommandLine
   HELP_TEXT = %{     potion version #{RedPotion::VERSION}
@@ -58,7 +56,6 @@ class PotionCommandLine
       :collection_view_controller,
       :table_view_controller
     ]
-
 
     def create(template_or_app_name, *options)
       if template_or_app_name.nil?


### PR DESCRIPTION
Based on @markrickert 's comments - I noticed that this seems to perform faster (though I am not sure thats what the problem that mark was seeing...

```shell
time ./live_gem
./live_gem  8.24s user 1.00s system 99% cpu 9.323 total
time ./tweaked_gem
./tweaked_gem  0.68s user 0.40s system 92% cpu 1.164 total
```

both of the above scripts are simply calling `potion -v` 10 times in a row, the tweaked version has what is changed here in this PR and repeatedly is much faster every time I time them.