### PR TITLE
Fix TableScreen searchable

### DIFF
--- a/app/screens/tasks_screen.rb
+++ b/app/screens/tasks_screen.rb
@@ -18,13 +18,15 @@ class TasksScreen < PM::TableScreen
           cell_class: TaskCell,
           properties: {
             my_title: "First task"
-          }
+          },
+          search_text: "First task",
         },
         {
           cell_class: TaskCell,
           properties: {
             my_title: "Second task"
-          }
+          },
+          search_text: "Second task",
         }
       ]
     }]

--- a/lib/project/pro_motion/data_table_searchable.rb
+++ b/lib/project/pro_motion/data_table_searchable.rb
@@ -3,14 +3,12 @@ module ProMotion
     module Searchable
 
       def make_data_table_searchable(params={})
-        if self.is_a?(ProMotion::DataTableScreen)
-          if params[:search_bar][:fields].nil?
-            raise "ERROR: You must specify fields:[:example] for your searchable DataTableScreen. It should be an array of fields you want searched in CDQ."
-          else
-            @data_table_predicate_fields = params[:search_bar][:fields]
-          end
-          params[:delegate] = search_delegate
+        if params[:search_bar][:fields].nil?
+          raise "ERROR: You must specify fields:[:example] for your searchable DataTableScreen. It should be an array of fields you want searched in CDQ."
+        else
+          @data_table_predicate_fields = params[:search_bar][:fields]
         end
+        params[:delegate] = search_delegate
 
         make_searchable(params)
       end

--- a/lib/project/pro_motion/data_table_searchable.rb
+++ b/lib/project/pro_motion/data_table_searchable.rb
@@ -2,21 +2,17 @@ module ProMotion
   module Table
     module Searchable
 
-      # Replace this method so that we can gather the predicate fields for DataTableScreen searchable
-      alias_method :old_set_searchable_param_defaults, :set_searchable_param_defaults
-      def set_searchable_param_defaults(params)
-        all_params = old_set_searchable_param_defaults(params)
-
+      def make_data_table_searchable(params={})
         if self.is_a?(ProMotion::DataTableScreen)
           if params[:search_bar][:fields].nil?
             raise "ERROR: You must specify fields:[:example] for your searchable DataTableScreen. It should be an array of fields you want searched in CDQ."
           else
-            @data_table_predicate_fields = all_params[:search_bar][:fields]
+            @data_table_predicate_fields = params[:search_bar][:fields]
           end
-          all_params[:delegate] = search_delegate
+          params[:delegate] = search_delegate
         end
 
-        all_params
+        make_searchable(params)
       end
 
       def search_fetch_controller

--- a/lib/project/pro_motion/data_table_searchable.rb
+++ b/lib/project/pro_motion/data_table_searchable.rb
@@ -13,9 +13,9 @@ module ProMotion
           else
             @data_table_predicate_fields = all_params[:search_bar][:fields]
           end
+          all_params[:delegate] = search_delegate
         end
 
-        all_params[:delegate] = search_delegate
         all_params
       end
 

--- a/lib/project/pro_motion/table.rb
+++ b/lib/project/pro_motion/table.rb
@@ -5,4 +5,22 @@ module ProMotion
       self.rmq.build(cell)
     end
   end
+
+  # This is duplicated from ProMotion in order to be call
+  # make_data_table_searchable instead of make_searchable
+  module Table
+    def set_up_searchable
+      if self.class.respond_to?(:get_searchable) && self.class.get_searchable
+        if self.is_a?(ProMotion::DataTableScreen)
+          self.make_data_table_searchable(content_controller: self, search_bar: self.class.get_searchable_params)
+        else
+          self.make_searchable(content_controller: self, search_bar: self.class.get_searchable_params)
+        end
+        if self.class.get_searchable_params[:hide_initially]
+          self.tableView.contentOffset = CGPointMake(0, self.searchDisplayController.searchBar.frame.size.height)
+        end
+      end
+    end
+  end
+
 end

--- a/spec/pro_motion/data_table_screen_spec.rb
+++ b/spec/pro_motion/data_table_screen_spec.rb
@@ -209,6 +209,10 @@ describe 'DataTableScreen' do
       @controller.class.get_searchable.should == true
     end
 
+    it "should have the correct delegate" do
+      @controller.tableView.delegate.search_delegate.class.should == DataTableSeachDelegate
+    end
+
     it "should create a search header" do
       @controller.tableView.tableHeaderView.should.be.kind_of UISearchBar
     end


### PR DESCRIPTION
Also add search text to the example table screen in the app so that there are results when searching.

This should be merged asap and a minor version released since `PM::TableScreen` searching is broken in `v1.4.0`

Closes #134 