### PR TITLE
Added open and close to REPL

### DIFF
--- a/docs/redpotion_specific_features.md
+++ b/docs/redpotion_specific_features.md
@@ -35,6 +35,8 @@ nil.blank? => true
 * `enable_live_stylesheets` aliases `enable_rmq_live_stylesheets`
 * `on_load` aliases `rmq_build` in views. This is great as it now matches screens
 * `on_styled` aliases `rmq_style_applied`
+* `open` in the REPL aliases `find.screen.open(*)`
+* `close` in the REPL aliases `find.screen.close(*)`
 
 ## append, create, build, on, off, apply_style, etc inside of a view
 

--- a/lib/project/ext/kernel.rb
+++ b/lib/project/ext/kernel.rb
@@ -1,11 +1,19 @@
 if RUBYMOTION_ENV == "development"
-  module Kernel
+  class TopLevel
     def live(interval = 1.0, debug=false)
       rmq_live_stylesheets interval, debug
     end
 
     def enable_live_stylesheets(interval)
       enable_rmq_live_stylesheets interval
+    end
+
+    def open(screen, args={})
+      find.screen.open(screen, args)
+    end
+
+    def close(args={})
+      find.screen.close(args)
     end
   end
 end


### PR DESCRIPTION
Also changed from `Kernel` to `TopLevel` to avoid polluting everything. We should always use `TopLevel` for REPL commands.

cc @GantMan 