### PR TITLE
Add a remote_image method that can take a block

### DIFF
--- a/lib/project/ext/ui_image_view.rb
+++ b/lib/project/ext/ui_image_view.rb
@@ -1,6 +1,16 @@
 class UIImageView
 
-  def remote_image=(value)
+  def remote_image=(url)
+    load_remote_image(url)
+  end
+
+  def remote_image(args)
+    load_remote_image(arg.fetch(:url), args.fetch(:block))
+  end
+
+  private
+
+  def load_remote_image(url, block = -> {})
     if !!defined?(SDWebImageManager)
       @remote_image_operations ||= {}
 
@@ -11,13 +21,14 @@ class UIImageView
         @remote_image_operations[("%p" % self)] = nil
       end
 
-      value = NSURL.URLWithString(value) unless value.is_a?(NSURL)
+      value = NSURL.URLWithString(url) unless url.is_a?(NSURL)
       @remote_image_operations[("%p" % self)] = SDWebImageManager.sharedManager.downloadWithURL(value,
         options:SDWebImageRefreshCached,
         progress:nil,
         completed: -> image, error, cacheType, finished {
           Dispatch::Queue.main.async do
             self.image = image
+            block.call
           end unless image.nil?
       })
     else


### PR DESCRIPTION
Previously it was hard to tell when an image had finished loading from
a URL. Having the ability to call remote_image with a block that will
execute when an image finishes loading makes this super easy. Being
able to do this is useful when displaying spinners as they can now be
removed easily at the appropriate time.

The `remote_image` method is separate from the setter method
`remote_image=` to adhere to the convention of setter methods and to
provide a clear interface.