### PR TITLE
Extend `remote_image=` to take a closure

### DIFF
--- a/docs/cookbook/images.md
+++ b/docs/cookbook/images.md
@@ -53,16 +53,21 @@ class MyStylesheet < ApplicationStylesheet
 end
 ```
 
-You can also call `remote_image` with a closure to execute once the remote image has finished loading. It takes a hash with `url` and `did_load` keys.
+You can also set `remote_image` with a hash that includes `url` and `on_load`
+keys. The `on_load` key should contain a closure to execute once the remote
+image has finished loading.
 
+Extending on the example above:
 ```ruby
-your_ui_image_view.remote_image({ url: 'http://bit.ly/18iMhwc',
-                                  did_load: -> { puts 'Image finished loading!' } })
-
-# Or
-
-your_ui_image_view.remote_image({ url: NSURL.urlWithString(...),
-                                  did_load: -> { puts 'Image finished loading!' } })
+class MyStylesheet < ApplicationStylesheet
+  def my_ui_image_view(st)
+    # ...
+    st.remote_image = { url: 'http://bit.ly/18iMhwc',
+                        on_load: -> { puts 'Image finished loading!' } }
+    # Or st.remote_image = { url: NSURL.urlWithString(...),
+    #                        on_load: -> { puts 'Image finished loading!' } }
+  end
+end
 ```
 
 To assign a remote image to a UIImageView:

--- a/docs/cookbook/images.md
+++ b/docs/cookbook/images.md
@@ -53,6 +53,18 @@ class MyStylesheet < ApplicationStylesheet
 end
 ```
 
+You can also call `remote_image` with a closure to execute once the remote image has finished loading. It takes a hash with `url` and `did_load` keys.
+
+```ruby
+your_ui_image_view.remote_image({ url: 'http://bit.ly/18iMhwc',
+                                  did_load: -> { puts 'Image finished loading!' } })
+
+# Or
+
+your_ui_image_view.remote_image({ url: NSURL.urlWithString(...),
+                                  did_load: -> { puts 'Image finished loading!' } })
+```
+
 To assign a remote image to a UIImageView:
 
 ```ruby

--- a/lib/project/ext/ui_image_view.rb
+++ b/lib/project/ext/ui_image_view.rb
@@ -1,16 +1,14 @@
 class UIImageView
 
-  def remote_image=(url)
-    load_remote_image(url)
-  end
-
-  def remote_image(args)
-    load_remote_image(args.fetch(:url), args.fetch(:did_load))
+  def remote_image=(args)
+    url = args.respond_to?(:fetch) ? args.fetch(:url) : args
+    on_load = args.respond_to?(:fetch) ? args.fetch(:on_load, -> {}) : -> {}
+    load_remote_image(url, on_load)
   end
 
   private
 
-  def load_remote_image(url, did_load = -> {})
+  def load_remote_image(url, on_load = -> {})
     if !!defined?(SDWebImageManager)
       @remote_image_operations ||= {}
 
@@ -28,7 +26,7 @@ class UIImageView
         completed: -> image, error, cacheType, finished {
           Dispatch::Queue.main.async do
             self.image = image
-            did_load.call
+            on_load.call
           end unless image.nil?
       })
     else

--- a/spec/ext/ui_image_view_spec.rb
+++ b/spec/ext/ui_image_view_spec.rb
@@ -1,7 +1,11 @@
 describe 'UIImageView' do
   
-  it "should respond to remote_image" do
+  it "should respond to remote_image=" do
     UIImageView.new.should.respond_to?(:remote_image=)
   end
   
+  it "should respond to remote_image" do
+    UIImageView.new.should.respond_to?(:remote_image)
+  end
+
 end

--- a/spec/ext/ui_image_view_spec.rb
+++ b/spec/ext/ui_image_view_spec.rb
@@ -4,8 +4,4 @@ describe 'UIImageView' do
     UIImageView.new.should.respond_to?(:remote_image=)
   end
   
-  it "should respond to remote_image" do
-    UIImageView.new.should.respond_to?(:remote_image)
-  end
-
 end


### PR DESCRIPTION
Previously it was hard to tell when an image had finished loading from
a URL. Having the ability to set `remote_image` with a closure that will
execute when an image finishes loading makes this super easy. Being
able to do this is useful when displaying spinners as they can now be
removed easily at the appropriate time.