### PR TITLE
Add missing configuration for http requests to work

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -112,6 +112,11 @@ def on_load
 end
 ```
 
+If you want to preview images which are under not secured (under HTTP), add the following line in the `Rakefile`:
+```ruby
+app.info_plist['NSAppTransportSecurity'] = { 'NSAllowsArbitraryLoads' => true }
+```
+
 Now paste this URL in and hit **Go**
 `http://bit.ly/18iMhwc`
 


### PR DESCRIPTION
I was following the quickstart and the example used image with http, so I thought we should also mention about this fix to allow send http request instead of https.