### PR TITLE
Support SDWebImage v4 while maintaining backwards compatibility with v3

### DIFF
--- a/lib/project/ext/ui_image_view.rb
+++ b/lib/project/ext/ui_image_view.rb
@@ -1,27 +1,55 @@
 class UIImageView
 
-  def remote_image=(value)
-    if !!defined?(SDWebImageManager)
-      @remote_image_operations ||= {}
+  def remote_image=(args)
+    url = args.respond_to?(:fetch) ? args.fetch(:url) : args
+    callback = args.respond_to?(:fetch) ? args.fetch(:on_load, -> {}) : -> {}
+    load_remote_image(url, callback)
+  end
 
+  private
+
+  def load_remote_image(url, callback = nil)
+    if defined?(SDWebImageManager)
+      @remote_image_operations ||= {}
       # Cancel the previous remote operation if it exists
       operation = @remote_image_operations[("%p" % self)]
       if operation && operation.respond_to?(:cancel)
         operation.cancel
         @remote_image_operations[("%p" % self)] = nil
       end
+      url = NSURL.URLWithString(url) unless url.is_a?(NSURL)
+      @remote_image_operations[("%p" % self)] = load_remote_image_using_sdwebimage(url, callback)
+    else
+      puts "\n[RedPotion ERROR]  tried to set remote_image without SDWebImage CocoaPod. Please add this to your Rakefile: \n\napp.pods do\n  pod \"SDWebImage\"\nend\n"
+    end
+  end
 
-      value = NSURL.URLWithString(value) unless value.is_a?(NSURL)
-      @remote_image_operations[("%p" % self)] = SDWebImageManager.sharedManager.downloadWithURL(value,
-        options:SDWebImageRefreshCached,
-        progress:nil,
+  def load_remote_image_using_sdwebimage(url, callback = nil)
+    manager = SDWebImageManager.sharedManager
+    if manager.respond_to?('downloadWithURL:options:progress:completed')
+      # Support for SDWebImage v3.x
+      manager.downloadWithURL(url,
+        options: SDWebImageRefreshCached,
+        progress: nil,
         completed: -> image, error, cacheType, finished {
           Dispatch::Queue.main.async do
             self.image = image
+            callback.call if callback
           end unless image.nil?
-      })
+        }
+      )
     else
-      puts "\n[RedPotion ERROR]  tried to set remote_image without SDWebImage cocoapod. Please add this to your Rakefile: \n\napp.pods do\n  pod \"SDWebImage\"\nend\n"
+      # Support for SDWebImage v4.x
+      manager.loadImageWithURL(url,
+        options: SDWebImageRefreshCached,
+        progress: nil,
+        completed: -> image, imageData, error, cacheType, finished, imageURL {
+          Dispatch::Queue.main.async do
+            self.image = image
+            callback.call if callback
+          end unless image.nil?
+        }
+      )
     end
   end
 

--- a/lib/project/ruby_motion_query/app.rb
+++ b/lib/project/ruby_motion_query/app.rb
@@ -14,12 +14,18 @@ module RubyMotionQuery
         if !!defined?(SDWebImageManager)
           image_cache = SDImageCache.sharedImageCache
           image_cache.clearMemory
-          image_cache.clearDisk
+          if image_cache.respond_to?(:clearDisk)
+            # Support for SDWebImage v3.x
+            image_cache.clearDisk
+          else
+            # Support for SDWebImage v4.x
+            image_cache.deleteOldFilesWithCompletion(nil)
+          end
         else
           puts "\n[RedPotion ERROR]  tried to reset image cache without SDWebImage cocoapod. Please add this to your Rakefile: \n\napp.pods do\n  pod \"SDWebImage\"\nend\n"
         end
       end
-      
+
     end
   end
 end


### PR DESCRIPTION
This PR adds support for SDWebImage v4 while maintaining backwards compatibility with v3. It also refactors the remote image handling code to make it slightly more maintainable.